### PR TITLE
Add Gesso (PHP OpenAPI contract testing library) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A curated list of awesome resources for Consumer-Driven Contracts Testing
 
 ## PHP
 - [PACT PHP](https://github.com/pact-foundation/pact-php) - PHP version of Pact. Enables consumer driven contract testing, providing a mock service and DSL for the consumer project, and interaction playback and verification for the service provider project.
+- [Gesso](https://studio-design.github.io/gesso/) - OpenAPI contract testing for PHP. Provider-side (spec-driven) contract testing with PHPUnit coverage, request/response validation, fuzzing, and drift detection. Adapters for Laravel, Symfony, Pest, and PSR-7.
 
 ## Python
 - [PACT Python](https://github.com/pact-foundation/pact-python) - Python version of Pact. Enables consumer driven contract testing, providing a mock service and DSL for the consumer project, and interaction playback and verification for the service provider project.


### PR DESCRIPTION
Adding [Gesso](https://studio-design.github.io/gesso/), an MIT-licensed PHP library for OpenAPI contract testing, to the PHP section.

Gesso complements PACT PHP by covering the provider-side / spec-driven flavour of contract testing: it validates HTTP requests and responses against an OpenAPI 3.0/3.1/3.2 schema inside PHPUnit, reports endpoint coverage against the spec, and runs schema-driven fuzzing plus drift detection. Ships framework-independent core plus Laravel, Symfony, Pest, and PSR-7 adapters.

Per CONTRIBUTING guidelines:
- Added to the end of the PHP list.
- Description starts with a capital and ends with a period.
- Single suggestion in this PR.
- Individual, focused change; no unrelated edits.

Docs: https://studio-design.github.io/gesso/
Source: https://github.com/studio-design/gesso
License: MIT